### PR TITLE
Logs

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,6 @@
 -*-change-log-*-
+3.2.1 Florian Eggenhofer <egg@informatik.uni-freiburg.de> 29. July 2019
+	* Added specific log files for use without queueing system
 3.2.0 Anica Scholz <a.scholz@biochem.uni-frankfurt.de> 26. June 2019
 	* added standard deviation to output files
 	* updated manual and docs

--- a/rules/report.smk
+++ b/rules/report.smk
@@ -6,4 +6,5 @@ rule ribotishreport:
     conda:
         "../envs/imagemagick.yaml"
     threads: 1
+    log: "logs/{condition}-{replicate}_ribotishreport.log"
     shell: ("mkdir -p report; convert -density 150 -trim {input}  -quality 100  -flatten -sharpen 0x1.0 {output};")

--- a/rules/ribotish.smk
+++ b/rules/ribotish.smk
@@ -7,6 +7,7 @@ rule ribobamindexlink:
         inlink=lambda wildcards, input:(os.getcwd() + "/" + str(input)),
         outlink=lambda wildcards, output:(os.getcwd() + "/" + str(output))
     threads: 1
+    log: "logs/{method}-{condition}-{replicate}_ribobamindexlink.log"
     shell:
         "mkdir -p maplink/RIBO/; ln -s {params.inlink} {params.outlink}"
 

--- a/rules/ribotish.smk
+++ b/rules/ribotish.smk
@@ -9,7 +9,7 @@ rule ribobamindexlink:
     threads: 1
     log: "logs/{method}-{condition}-{replicate}_ribobamindexlink.log"
     shell:
-        "mkdir -p maplink/RIBO/; ln -s {params.inlink} {params.outlink}"
+        "mkdir -p maplink/RIBO/; ln -s {params.inlink} {params.outlink} 2> {log}"
 
 rule ribotishQuality:
     input:

--- a/rules/uORF-Tools.smk
+++ b/rules/uORF-Tools.smk
@@ -9,6 +9,7 @@ rule riboMerge:
     threads: 1
     params:
         annotationpath=lambda wildcards: ("NOTSET" if not UORFANNOTATIONPATH else (UORFANNOTATIONPATH))
+    log: "logs/riboMerge.log"
     shell:
         "if [ -e {params.annotationpath} ]; then export APATH=`readlink -f {params.annotationpath}`; mkdir -p uORFs; ln -T -s $APATH {output.csv}; uORF-Tools/scripts/ribo_convert.py --input_csv_filepath $APATH --output_bed_filepath {output.bed}; else mkdir -p uORFs; uORF-Tools/scripts/ribo_merge.py {input} --min_length 1 --max_length 400 --output_csv_filepath {output.csv} --output_bed_filepath {output.bed}; fi"
 
@@ -20,6 +21,7 @@ rule longestTranscript:
     conda:
         "../envs/uorftoolspython.yaml"
     threads: 1
+    log: "logs/longestTranscript.log"
     shell:
         "mkdir -p uORFs; uORF-Tools/scripts/longest_orf_transcript.py -a {input} -o {output}"
 
@@ -32,6 +34,7 @@ rule sizeFactors:
     conda:
         "../envs/uorftools.yaml"
     threads: 1
+    log: "logs/sizeFactors.log"
     shell: ("mkdir -p uORFs; uORF-Tools/scripts/generate_size_factors.R -t uORF-Tools/samples.tsv -b maplink/ -a {input.longestTranscript} -s uORFs/sfactors_lprot.csv;")
 
 rule cdsRiboCounts:
@@ -45,6 +48,7 @@ rule cdsRiboCounts:
     conda:
         "../envs/uorftools.yaml"
     threads: 1
+    log: "logs/cdsRiboCounts.log"
     shell: ("mkdir -p uORFs; uORF-Tools/scripts/generate_ribo_counts_CDS.R -b maplink/RIBO/ -a {input.annotation} -s {input.sizefactor} -t uORF-Tools/samples.tsv -n {output.norm} -r {output.raw};")
 
 rule uORFRiboCounts:
@@ -58,6 +62,7 @@ rule uORFRiboCounts:
     conda:
         "../envs/uorftools.yaml"
     threads: 1
+    log: "logs/uORFRiboCounts.log"
     shell: ("mkdir -p uORFs; uORF-Tools/scripts/generate_ribo_counts_uORFs.R -b maplink/RIBO/ -a {input.annotation} -s {input.sizefactor} -t uORF-Tools/samples.tsv -n {output.norm} -r {output.raw};")
 
 rule riboChanges:
@@ -69,6 +74,7 @@ rule riboChanges:
     conda:
         "../envs/uorftoolspython.yaml"
     threads: 1
+    log: "logs/riboChanges.log"
     shell: ("mkdir -p uORFs; uORF-Tools/scripts/ribo_changes.py --uORF_reads {input.uorf} --ORF_read {input.orf} --changes_output {output.frac};")
 
 rule final_table:
@@ -81,4 +87,5 @@ rule final_table:
     conda:
         "../envs/uorftoolspython.yaml"
     threads: 1
+    log: "logs/final_table.log"
     shell: ("mkdir -p uORFs; uORF-Tools/scripts/final_table.py --uORF_reads {input.uORFreads} --ORF_reads {input.cdsreads} --uORF_annotation {input.annotation} --output_csv_filepath {output}")

--- a/rules/uORF-Tools.smk
+++ b/rules/uORF-Tools.smk
@@ -11,7 +11,7 @@ rule riboMerge:
         annotationpath=lambda wildcards: ("NOTSET" if not UORFANNOTATIONPATH else (UORFANNOTATIONPATH))
     log: "logs/riboMerge.log"
     shell:
-        "if [ -e {params.annotationpath} ]; then export APATH=`readlink -f {params.annotationpath}`; mkdir -p uORFs; ln -T -s $APATH {output.csv}; uORF-Tools/scripts/ribo_convert.py --input_csv_filepath $APATH --output_bed_filepath {output.bed}; else mkdir -p uORFs; uORF-Tools/scripts/ribo_merge.py {input} --min_length 1 --max_length 400 --output_csv_filepath {output.csv} --output_bed_filepath {output.bed}; fi"
+        "if [ -e {params.annotationpath} ]; then export APATH=`readlink -f {params.annotationpath}`; mkdir -p uORFs; ln -T -s $APATH {output.csv}; uORF-Tools/scripts/ribo_convert.py --input_csv_filepath $APATH --output_bed_filepath {output.bed} 2> {log}; else mkdir -p uORFs; uORF-Tools/scripts/ribo_merge.py {input} --min_length 1 --max_length 400 --output_csv_filepath {output.csv} --output_bed_filepath {output.bed} 2>> {log}; fi"
 
 rule longestTranscript:
     input:
@@ -23,7 +23,7 @@ rule longestTranscript:
     threads: 1
     log: "logs/longestTranscript.log"
     shell:
-        "mkdir -p uORFs; uORF-Tools/scripts/longest_orf_transcript.py -a {input} -o {output}"
+        "mkdir -p uORFs; uORF-Tools/scripts/longest_orf_transcript.py -a {input} -o {output} 2> {log}"
 
 rule sizeFactors:
     input:
@@ -35,7 +35,7 @@ rule sizeFactors:
         "../envs/uorftools.yaml"
     threads: 1
     log: "logs/sizeFactors.log"
-    shell: ("mkdir -p uORFs; uORF-Tools/scripts/generate_size_factors.R -t uORF-Tools/samples.tsv -b maplink/ -a {input.longestTranscript} -s uORFs/sfactors_lprot.csv;")
+    shell: ("mkdir -p uORFs; uORF-Tools/scripts/generate_size_factors.R -t uORF-Tools/samples.tsv -b maplink/ -a {input.longestTranscript} -s uORFs/sfactors_lprot.csv 2> {log};")
 
 rule cdsRiboCounts:
     input:
@@ -49,7 +49,7 @@ rule cdsRiboCounts:
         "../envs/uorftools.yaml"
     threads: 1
     log: "logs/cdsRiboCounts.log"
-    shell: ("mkdir -p uORFs; uORF-Tools/scripts/generate_ribo_counts_CDS.R -b maplink/RIBO/ -a {input.annotation} -s {input.sizefactor} -t uORF-Tools/samples.tsv -n {output.norm} -r {output.raw};")
+    shell: ("mkdir -p uORFs; uORF-Tools/scripts/generate_ribo_counts_CDS.R -b maplink/RIBO/ -a {input.annotation} -s {input.sizefactor} -t uORF-Tools/samples.tsv -n {output.norm} -r {output.raw} 2> {log};")
 
 rule uORFRiboCounts:
     input:
@@ -63,7 +63,7 @@ rule uORFRiboCounts:
         "../envs/uorftools.yaml"
     threads: 1
     log: "logs/uORFRiboCounts.log"
-    shell: ("mkdir -p uORFs; uORF-Tools/scripts/generate_ribo_counts_uORFs.R -b maplink/RIBO/ -a {input.annotation} -s {input.sizefactor} -t uORF-Tools/samples.tsv -n {output.norm} -r {output.raw};")
+    shell: ("mkdir -p uORFs; uORF-Tools/scripts/generate_ribo_counts_uORFs.R -b maplink/RIBO/ -a {input.annotation} -s {input.sizefactor} -t uORF-Tools/samples.tsv -n {output.norm} -r {output.raw} 2> {log};")
 
 rule riboChanges:
     input:
@@ -75,7 +75,7 @@ rule riboChanges:
         "../envs/uorftoolspython.yaml"
     threads: 1
     log: "logs/riboChanges.log"
-    shell: ("mkdir -p uORFs; uORF-Tools/scripts/ribo_changes.py --uORF_reads {input.uorf} --ORF_read {input.orf} --changes_output {output.frac};")
+    shell: ("mkdir -p uORFs; uORF-Tools/scripts/ribo_changes.py --uORF_reads {input.uorf} --ORF_read {input.orf} --changes_output {output.frac} 2> {log};")
 
 rule final_table:
     input:
@@ -88,4 +88,4 @@ rule final_table:
         "../envs/uorftoolspython.yaml"
     threads: 1
     log: "logs/final_table.log"
-    shell: ("mkdir -p uORFs; uORF-Tools/scripts/final_table.py --uORF_reads {input.uORFreads} --ORF_reads {input.cdsreads} --uORF_annotation {input.annotation} --output_csv_filepath {output}")
+    shell: ("mkdir -p uORFs; uORF-Tools/scripts/final_table.py --uORF_reads {input.uORFreads} --ORF_reads {input.cdsreads} --uORF_annotation {input.annotation} --output_csv_filepath {output} 2> {log}")


### PR DESCRIPTION
Redirects output from stderr to specific log files in the logs directory. This captures errors when using uORF-Tools without queueing system. Fixed environment for longest_transcripts rules.